### PR TITLE
Allow "," in element id

### DIFF
--- a/src/com/google/caja/plugin/domado.js
+++ b/src/com/google/caja/plugin/domado.js
@@ -1373,7 +1373,7 @@ var Domado = (function() {
 
     var VALID_ID_CHAR =
         unicode.LETTER + unicode.DIGIT + '_'
-        + '$\\-.:;=()\\[\\]'
+        + '$\\-.,:;=()\\[\\]'
         + unicode.COMBINING_CHAR + unicode.EXTENDER;
 
     var VALID_ID_PATTERN = new RegExp(
@@ -7448,7 +7448,7 @@ var Domado = (function() {
       getDomicileForWindow: windowToDomicile.get.bind(windowToDomicile)
     });
   }
-  
+
   /**
    * Invoke the possibly guest-supplied onerror handler due to an uncaught
    * exception. This wrapper exists to ensure consistent behavior among the
@@ -7503,7 +7503,7 @@ var Domado = (function() {
       }
     }
   });
-  
+
   return cajaVM.constFunc(Domado_);
 })();
 


### PR DESCRIPTION
This is a minimal fix to allow "," in the element id. 

Caja probably needs a story with a more comprehensive change, as it's already more permissive than then HTML4 specification.

HTML 4.01 specified that ID tokens must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens (-), underscores (_), colons (:), and periods (.).
http://www.w3.org/TR/html401/types.html#type-name

HTML5 got rid of those restrictions on the id attribute. Now class and id attributes are now very similar.  The only requirements left — apart from being unique in the document — are that the value must contain at least one character (can’t be empty), and that it can’t contain any space characters.
https://html.spec.whatwg.org/multipage/dom.html#classes
