### PR TITLE
Remove extra charset parameter if present

### DIFF
--- a/src/com/google/caja/plugin/ses-frame-group.js
+++ b/src/com/google/caja/plugin/ses-frame-group.js
@@ -322,6 +322,9 @@ function SESFrameGroup(cajaInt, config, tamingWin, feralWin,
       var contentType = opt_expectedContentType
         || xhrRecord.contentType;
 
+      // Remove extra charset parameter if present
+      contentType = contentType.split(";").shift();
+
       var theContent = xhrRecord.responseText;
 
       if (contentType === 'text/javascript'


### PR DESCRIPTION
Caja fails to load resources when the server returns the charset in the content type header.

This header works:

`content-type: application/javascript`

But this fails without the fix:

`content-type: application/javascript; charset=utf-8`

In that case, Caja throws an error:

> Unimplemented content-type application/javascript; charset=utf-8
