### PR TITLE
Fix missing comma in whitelist JSON.

### DIFF
--- a/src/com/google/caja/lang/css/css3-whitelist.json
+++ b/src/com/google/caja/lang/css/css3-whitelist.json
@@ -162,7 +162,7 @@
     "word-break",
     "word-spacing",
     "word-wrap",
-    "z-index"
+    "z-index",
     "zoom"
   ],
 


### PR DESCRIPTION
Fixes issue #2013.

Tests not run (we need a webdriver update, looks like, and I'll do that separately) but I put the file through a JSON parser to check it.