### PR TITLE
Remove form onsubmit restriction.

### DIFF
--- a/src/com/google/caja/plugin/domado.js
+++ b/src/com/google/caja/plugin/domado.js
@@ -1900,17 +1900,6 @@ var Domado = (function() {
 
       var elementPolicies = {};
       elementPolicies.form = function (attribs) {
-        // Forms must have a gated onsubmit handler or they must have an
-        // external target.
-        var sawHandler = false;
-        for (var i = 0, n = attribs.length; i < n; i += 2) {
-          if (attribs[+i] === 'onsubmit') {
-            sawHandler = true;
-          }
-        }
-        if (!sawHandler) {
-          attribs.push('onsubmit', 'return false');
-        }
         return forceAutocompleteOff(attribs);
       };
       elementPolicies.input = function (attribs) {
@@ -2308,14 +2297,9 @@ var Domado = (function() {
             )(tameWindow);
             var fnNameExpr = domicile.handlers.push(handlerFn) - 1;
 
-            var trustedHandler = '___.plugin_dispatchEvent___(this, event, ' +
+            var trustedHandler =
+                'return ___.plugin_dispatchEvent___(this, event, ' +
                 pluginId + ', ' + fnNameExpr + ');';
-            if (attribName === 'onsubmit') {
-              trustedHandler =
-                'try { ' + trustedHandler + ' } finally { return false; }';
-            } else {
-              trustedHandler = 'return ' + trustedHandler;
-            }
             return trustedHandler;
           case html4.atype.URI:
             value = String(value);

--- a/tests/com/google/caja/plugin/test-domado-forms-guest.html
+++ b/tests/com/google/caja/plugin/test-domado-forms-guest.html
@@ -171,7 +171,6 @@
   jsunitRegister('testForms',
                  function testForms() {
     var form = document.createElement('FORM');
-    assertEquals('return false', directAccess.getAttribute(form, 'onsubmit'));
 
     assertEquals('off', directAccess.getAttribute(form, 'autocomplete'));
     // TODO(felix8a): no such function in es5 in firefox?
@@ -190,11 +189,10 @@
     // TODO(kpreid): This is matching implementation details. What do we
     // actually want to test for here? At least:
     // * autocomplete="off"
-    // * try/finally forcing false return value
     assertEquals('<form autocomplete="off" onsubmit="'
-                 + 'try { ___.plugin_dispatchEvent___'
+                 + 'return ___.plugin_dispatchEvent___'
                  + '(this, event, 0, 0);'  // serial #s may change
-                 + ' } finally { return false; }" target="_blank">'
+                 + '" target="_blank">'
                  + '<input autocomplete="off" type="submit" value="Submit">'
                  + '</form>',
                  canonInnerHtml(directAccess.getInnerHTML(container)));

--- a/third_party/java/webdriver/README
+++ b/third_party/java/webdriver/README
@@ -1,3 +1,3 @@
 origin
-  http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar
+  http://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.1.jar
   from http://docs.seleniumhq.org/download/

--- a/third_party/java/webdriver/VERSION
+++ b/third_party/java/webdriver/VERSION
@@ -1,2 +1,2 @@
-Version: 2.53.0
-URL: http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar
+Version: 3.0.1
+URL: http://selenium-release.storage.googleapis.com/3.0/selenium-server-standalone-3.0.1.jar


### PR DESCRIPTION
The previous policy, of prohibiting any 'normal' form submit, was both stricter than the cajoler (ES5/3 mode) and silly, since it could be worked around in guest code with `onsubmit='this.submit();'`.