### PR TITLE
Fix CSS declaration skip after extra semicolon

### DIFF
--- a/src/com/google/caja/plugin/cssparser.js
+++ b/src/com/google/caja/plugin/cssparser.js
@@ -190,11 +190,7 @@ var parseCssDeclarations;
         ++i;
         break;
       }
-      if (tok === ' ') {
-        i = i+1;
-      } else {
-        i = declaration(toks, i, n, handler);
-      }
+      i = declaration(toks, i, n, handler);
     }
     if (handler['endRuleset']) {
       handler['endRuleset']();
@@ -255,6 +251,7 @@ var parseCssDeclarations;
   function declaration(toks, i, n, handler) {
     var property = toks[i++];
     if (!ident.test(property)) {
+      if (property === ' ' || property === ';') return i;
       return skipDeclaration(toks, i, n);
     }
     var tok;
@@ -309,7 +306,7 @@ var parseCssDeclarations;
   parseCssDeclarations = function(cssText, handler) {
     var toks = lexCss(cssText);
     for (var i = 0, n = toks.length; i < n;) {
-      i = toks[i] !== ' ' ? declaration(toks, i, n, handler) : i+1;
+      i = declaration(toks, i, n, handler);
     }
   };
 })();


### PR DESCRIPTION
Fixes #1993 

This issue happens because ``declaration()`` is called with a token list such as ``[";","margin",":","auto"]``, which recognizes ``;`` as an invalid identifier, and advances the token stream until the <i>next</i> semicolon (or closing brace).

With this patch, the parser will advance a single token when meeting either whitespace or a semicolon, thus fixing the issue.

Alternative patches that may be considered:
- https://github.com/Slayer95/caja/commit/37193dfd34c40b4f310234151ecdc2214812c1eb
- https://github.com/Slayer95/caja/commit/62a805510409a0fc57795bc81147a11a6becfba0
- Checking the previous token in ``skipDeclaration()`` ?
