### PR TITLE
Fix various broken tests.

### DIFF
--- a/tests/com/google/caja/browser-expectations.html
+++ b/tests/com/google/caja/browser-expectations.html
@@ -391,17 +391,17 @@
 
     jsunitRegister('testInstanceofWoutCtorThrows',
                    function testInstanceofWoutCtorThrows() {
-      assertThrowsMsg(function () { return ({}) instanceof 0; }, 'instanceof');
-      assertThrowsMsg(function () { return ({}) instanceof false; },
-          'instanceof');
-      assertThrowsMsg(function () { return ({}) instanceof 'Object'; },
-          'instanceof');
-      assertThrowsMsg(function () { return ({}) instanceof {}; },
-          'instanceof');
-      assertThrowsMsg(function () { return ({}) instanceof null; },
-          'instanceof');
-      assertThrowsMsg(function () { return ({}) instanceof undefined; },
-          'instanceof');
+      function assertInstanceofThrows(f) {
+        expectFailure(f, null, function (e) {
+          return /instanceof|not a function/.test('' + e);
+        });
+      }
+      assertInstanceofThrows(function () { return ({}) instanceof 0; });
+      assertInstanceofThrows(function () { return ({}) instanceof false; });
+      assertInstanceofThrows(function () { return ({}) instanceof 'Object'; });
+      assertInstanceofThrows(function () { return ({}) instanceof {}; });
+      assertInstanceofThrows(function () { return ({}) instanceof null; });
+      assertInstanceofThrows(function () { return ({}) instanceof undefined; });
       jsunit.pass();
     });
     </script>

--- a/tests/com/google/caja/lang/css/CssPropertyPatternsTest.java
+++ b/tests/com/google/caja/lang/css/CssPropertyPatternsTest.java
@@ -86,7 +86,7 @@ public class CssPropertyPatternsTest extends CajaTestCase {
         "'color'",
         "{\n"
         + "  'props': [ HASH_VALUE ],\n"
-        + "  'fns': [ 'rgb', 'rgba' ]\n"
+        + "  'fns': [ 'hsl', 'hsla', 'rgb', 'rgba' ]\n"
         + "}",
         "lits"  // Ignore all the many many color names.
         );

--- a/tests/com/google/caja/plugin/test-domado-dom-guest.html
+++ b/tests/com/google/caja/plugin/test-domado-dom-guest.html
@@ -2373,7 +2373,7 @@ After
       var note = record.note;
       var constructor = record.sample.constructor;
       if (!constructor ||
-          /^function (?:Object|Function|FakeFunction|Array)\b/
+          /^function\s+(?:Object|Function|FakeFunction|Array)\b/
               .test(constructor.toString()) ||
           record.constructorCallable) {
         // Not concerned with objects which don't expose their type,
@@ -2382,7 +2382,7 @@ After
       }
       expectFailure(function() {
         new constructor();
-      }, note, function(e) {
+      }, note + '(constructor=' + constructor + ')', function(e) {
         return /This constructor cannot be called directly\./.test(String(e));
       });
     });
@@ -3156,8 +3156,8 @@ Test row cell
       assertEquals('typeof ' + name, 'function', typeof window[name]);
 
       // Fail if this function turns into something non-noopish unexpectedly
-      assertTrue('name ' + name,
-          /^function domadoNoop/.test(String(window[name])));
+      assertTrue('name ' + name + ' -> ' + window[name],
+          /^function\s+domadoNoop/.test(String(window[name])));
 
       window[name]();  // should not fail
     });

--- a/tests/com/google/caja/plugin/test-domado-events-guest.html
+++ b/tests/com/google/caja/plugin/test-domado-events-guest.html
@@ -1076,7 +1076,9 @@ TODO(felix8a): fix javascript url handling
     assertEquals('initMouseEvent relatedTarget', document.body,
         event.relatedTarget);
 
-    // initKeyboardEvent/initKeyEvent (ack TODO)
+    // initKeyboardEvent/initKeyEvent
+    // Note that both of these methods are deprecated per MDN as of 2017-09-07
+    // and we should expect this test to break eventually.
     var keyboardOK = false;
     if (event.initKeyboardEvent) {
       event = document.createEvent('KeyboardEvent');
@@ -1092,9 +1094,6 @@ TODO(felix8a): fix javascript url handling
       assertEquals('initKeyboardEvent view', window, event.view);
       if (directAccess.feralFeatureTest(event, 'char')) {
         assertEquals('initKeyboardEvent char', 'q', event.char);
-      }
-      if (directAccess.feralFeatureTest(event, 'key')) {
-        assertEquals('initKeyboardEvent key', 'q', event.key);
       }
       assertEquals('initKeyboardEvent charCode', 0, event.charCode);
       assertEquals('initKeyboardEvent keyCode', 0, event.keyCode);

--- a/tests/com/google/caja/plugin/test-scan-guest.js
+++ b/tests/com/google/caja/plugin/test-scan-guest.js
@@ -653,6 +653,7 @@
     argsByAnyFrame('Array', freshResult(G.any(
         genAllCall(),
         genAllCall(genSmallInteger))));
+    argsByAnyFrame('Array.from', freshResult(genArrayCall(G.tuple(genArray))));
     argsByAnyFrame('Array.isArray', genArrayCall(G.tuple(genArray)));
     argsByAnyFrame('Array.prototype.concat',
         freshResult(genArrayCall(G.tuple(genArray))));


### PR DESCRIPTION
* CssPropertyPatternsTest needs to match whitelist data.
* Some tests were sensitive to whitespace in function declarations
  (via toString) which depends on the minification outcome.
* Scan coverage for Array.from.
* instanceof error message changed on Firefox.
* initKeyboardEvent is dying slowly.