### PR TITLE
In tamperProof, prevent the getter from redefining properties.

### DIFF
--- a/src/com/google/caja/ses/repairES5.js
+++ b/src/com/google/caja/ses/repairES5.js
@@ -408,14 +408,15 @@ var ses;
             }
             if (!!gopd(this, name)) {
               this[name] = newValue;
+            } else {
+              // TODO(erights): Do all the inherited property checks
+              defProp(this, name, {
+                value: newValue,
+                writable: true,
+                enumerable: true,
+                configurable: true
+              });
             }
-            // TODO(erights): Do all the inherited property checks
-            defProp(this, name, {
-              value: newValue,
-              writable: true,
-              enumerable: true,
-              configurable: true
-            });
           }
           var desc = gopd(obj, name);
           if ('value' in desc) {


### PR DESCRIPTION
In the getter created by the tamperProof function:  
```
          function setter(newValue) {
            if (obj === this) {
              throw new TypeError('Cannot set virtually frozen property: ' +
                                  name);
            }
            if (!!gopd(this, name)) {
              this[name] = newValue;
            }
            // TODO(erights): Do all the inherited property checks
            defProp(this, name, {
              value: newValue,
              writable: true,
              enumerable: true,
              configurable: true
            });
          }
```
Currently, an attempt is made to redefine the property every time setter is invoked. 

The definition of the property apparently needs to move to the else block of the check to see if the property exists.
```
          if (!!gopd(this, name)) {
              // assign
          } else {
             // define
          }
```