### PR TITLE
Support override of ALLOWED_URI_SCHEMES with html4.allowedUriSchemes

### DIFF
--- a/src/com/google/caja/plugin/html-sanitizer.js
+++ b/src/com/google/caja/plugin/html-sanitizer.js
@@ -812,13 +812,17 @@ var html = (function(html4) {
 
   var ALLOWED_URI_SCHEMES = /^(?:https?|geo|mailto|sms|tel)$/i;
 
+  function getAllowedUriSchemes() {
+	  return html4.allowedUriSchemes || ALLOWED_URI_SCHEMES;
+  }
+  
   function safeUri(uri, effect, ltype, hints, naiveUriRewriter) {
     if (!naiveUriRewriter) { return null; }
     try {
       var parsed = URI.parse('' + uri);
       if (parsed) {
         if (!parsed.hasScheme() ||
-            ALLOWED_URI_SCHEMES.test(parsed.getScheme())) {
+            getAllowedUriSchemes().test(parsed.getScheme())) {
           var safe = naiveUriRewriter(parsed, effect, ltype, hints);
           return safe ? safe.toString() : null;
         }

--- a/src/com/google/caja/plugin/sanitizecss.js
+++ b/src/com/google/caja/plugin/sanitizecss.js
@@ -92,6 +92,10 @@ var sanitizeMediaQuery = undefined;
 
   var ALLOWED_URI_SCHEMES = /^(?:https?|geo|mailto|sms|tel)$/i;
 
+  function getAllowedUriSchemes() {
+	  return html4.allowedUriSchemes || ALLOWED_URI_SCHEMES;
+  }
+  
   function resolveUri(baseUri, uri) {
     if (baseUri) {
       return URI.utils.resolve(baseUri, uri);
@@ -102,7 +106,7 @@ var sanitizeMediaQuery = undefined;
   function safeUri(uri, prop, naiveUriRewriter) {
     if (!naiveUriRewriter) { return null; }
     var parsed = ('' + uri).match(URI_SCHEME_RE);
-    if (parsed && (!parsed[1] || ALLOWED_URI_SCHEMES.test(parsed[1]))) {
+    if (parsed && (!parsed[1] || getAllowedUriSchemes().test(parsed[1]))) {
       return naiveUriRewriter(uri, prop);
     } else {
       return null;


### PR DESCRIPTION
This indirectly addresses [Issue 1558](https://github.com/google/caja/issues/1558).

That issue is about data: and javascript: not being allowed protocols for URIs.  This change allows the HTML sanitizer to be configured to allow any URI protocol by using a new html4 attribute, allowedUriSchemes.  This custom attribute, if defined, will be used instead of the hardcoded RegEx ALLOWED_URI_SCHEMES.

For instance, to allow both data: and javascript: URIs:
```
html4.allowedUriSchemes = /^(?:https?|geo|mailto|sms|tel|data|javascript)$/i;
var newHTML = html_sanitize(oldHTML);
```